### PR TITLE
Use default compiler parameters and don't throw in destructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:Ws2_32>
 )
 
-# Common compile options.
-
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 # PC/SC API dependencies.
 
 add_library(pcsc INTERFACE)

--- a/include/pcsc-cpp/pcsc-cpp.hpp
+++ b/include/pcsc-cpp/pcsc-cpp.hpp
@@ -209,7 +209,7 @@ public:
     {
     public:
         TransactionGuard(const CardImpl& CardImpl, bool& inProgress);
-        ~TransactionGuard() noexcept(false);
+        ~TransactionGuard();
 
         // The rule of five (C++ Core guidelines C.21).
         TransactionGuard(const TransactionGuard&) = delete;

--- a/src/SmartCard.cpp
+++ b/src/SmartCard.cpp
@@ -242,12 +242,14 @@ SmartCard::TransactionGuard::TransactionGuard(const CardImpl& card, bool& inProg
     inProgress = true;
 }
 
-SmartCard::TransactionGuard::~TransactionGuard() noexcept(false)
+SmartCard::TransactionGuard::~TransactionGuard()
 {
     inProgress = false;
-    // endTransaction() may throw, should be OK as TransactionGuard does not own resources.
-    // TODO: Log in case endTransaction() throws.
-    card.endTransaction();
+    try {
+        card.endTransaction();
+    } catch (...) {
+        // Ignore exceptions in destructor.
+    }
 }
 
 SmartCard::SmartCard(const ContextPtr& contex, const string_t& readerName, byte_vector atr) :


### PR DESCRIPTION
WE2-404

Signed-off-by: Raul Metsma <raul@metsma.ee>