### PR TITLE
Replace  PCSC_LIBRARIES with PCSC_LINK_LIBRARIES in CMake  target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(PCSC libpcsclite REQUIRED)
   target_include_directories(${PROJECT_NAME} PRIVATE ${PCSC_INCLUDE_DIRS})
-  target_link_libraries(pcsc INTERFACE ${PCSC_LIBRARIES})
+  target_link_libraries(pcsc INTERFACE ${PCSC_LINK_LIBRARIES})
 endif()
 
 # Common testing options.


### PR DESCRIPTION
The build fails when libpcsc is not in a standard linker search
path (but pkg-config correctly finds and references its location).
${PCSC_LIBRARIES} only references `-lpcsclite' (without the
path info), which is the actual cause of the failure.

Replace ${PCSC_LIBRARIES} with ${PCSC_LINK_LIBRARIES}, which also
adds the libpcsc install location to the link command.