### PR TITLE
Fix result code type narrowing in SCardCall.hpp

### DIFF
--- a/src/SCardCall.hpp
+++ b/src/SCardCall.hpp
@@ -47,7 +47,14 @@ void SCardCall(const char* callerFunctionName, const char* file, int line,
                const char* scardFunctionName, Func scardFunction, Args... args)
 {
     // TODO: Add logging - or is exception error message enough?
+
+#ifdef __APPLE__
+    // Apple version of pcsc-lite uses unsigned code constants
     const uint32_t result = scardFunction(args...);
+#else
+    // Standard version of pcsc-lite uses signed code constants
+    const LONG result = scardFunction(args...);
+#endif
 
     // TODO: Add more cases when needed.
     switch (result) {


### PR DESCRIPTION
Fix result code type narrowing in SCardCall.hpp
----
SCardCall.hpp compilation causes errors on 32-bit platforms ( debian bullseye, gcc v10.2.1). This is caused by wrong type of  `scardFunction` result code.

Currently this is `uint32_t`, but this conflicts with with error codes defined in `pcsc-lite` library: https://github.com/max2344/pcsc-lite/blob/master/src/PCSC/pcsclite.h#L103-L166 Error codes are defined as `LONG` , which is signed, and conflicts `uint32_t`. (See also https://github.com/max2344/pcsc-lite/blob/master/src/PCSC/wintypes.h#L94)

This error is observable only during compilation on 32-bit platform, 64-bit compilation was correct.

`auto` kind of solves this problem, but maybe a proper destination type is better.

Initial compilation message:
```
/tmp/web-eid-app/lib/libelectronic-id/lib/libpcsc-cpp/src/SCardCall.hpp: In instantiation of ‘void pcsc_cpp::SCardCall(const char*, const char*, int, const char*, Func, Args ...) [with Func = long int (*)(long unsigned int, const void*, const void*, long int*); Args = {int, std::nullptr_t, std::nullptr_t, long int*}]’:
/tmp/web-eid-app/lib/libelectronic-id/lib/libpcsc-cpp/src/Context.hpp:40:9:   required from here
/tmp/web-eid-app/lib/libelectronic-id/lib/libpcsc-cpp/src/SCardCall.hpp:56:5: error: narrowing conversion of ‘-2146435043’ from ‘LONG’ {aka ‘long int’} to ‘unsigned int’ [-Wnarrowing]
   56 |     case SCARD_E_NO_SERVICE:
      |     ^~~~
/tmp/web-eid-app/lib/libelectronic-id/lib/libpcsc-cpp/src/SCardCall.hpp:57:5: error: narrowing conversion of ‘-2146435042’ from ‘LONG’ {aka ‘long int’} to ‘unsigned int’ [-Wnarrowing]
   57 |     case SCARD_E_SERVICE_STOPPED:
      |     ^~~~
/tmp/web-eid-app/lib/libelectronic-id/lib/libpcsc-cpp/src/SCardCall.hpp:60:5: error: narrowing conversion of ‘-2146435026’ from ‘LONG’ {aka ‘long int’} to ‘unsigned int’ [-Wnarrowing]
   60 |     case SCARD_E_NO_READERS_AVAILABLE:

```