### PR TITLE
refactor: add PCSC_CPP_DISABLE_COPY_MOVE macro to implement The Rule of Five

### DIFF
--- a/include/pcsc-cpp/pcsc-cpp.hpp
+++ b/include/pcsc-cpp/pcsc-cpp.hpp
@@ -28,6 +28,13 @@
 #include <vector>
 #include <limits>
 
+// The rule of five (C++ Core guidelines C.21).
+#define PCSC_CPP_DISABLE_COPY_MOVE(Class)                                                          \
+    Class(const Class&) = delete;                                                                  \
+    Class& operator=(const Class&) = delete;                                                       \
+    Class(Class&&) = delete;                                                                       \
+    Class& operator=(Class&&) = delete
+
 namespace pcsc_cpp
 {
 
@@ -216,12 +223,7 @@ public:
     public:
         TransactionGuard(const CardImpl& CardImpl, bool& inProgress);
         ~TransactionGuard();
-
-        // The rule of five (C++ Core guidelines C.21).
-        TransactionGuard(const TransactionGuard&) = delete;
-        TransactionGuard& operator=(const TransactionGuard&) = delete;
-        TransactionGuard(TransactionGuard&&) = delete;
-        TransactionGuard& operator=(TransactionGuard&&) = delete;
+        PCSC_CPP_DISABLE_COPY_MOVE(TransactionGuard);
 
     private:
         const CardImpl& card;
@@ -231,12 +233,7 @@ public:
     SmartCard(const ContextPtr& context, const string_t& readerName, byte_vector atr);
     SmartCard(); // Null object constructor.
     ~SmartCard();
-
-    // The rule of five.
-    SmartCard(const SmartCard&) = delete;
-    SmartCard& operator=(const SmartCard&) = delete;
-    SmartCard(SmartCard&&) = delete;
-    SmartCard& operator=(SmartCard&&) = delete;
+    PCSC_CPP_DISABLE_COPY_MOVE(SmartCard);
 
     TransactionGuard beginTransaction();
     ResponseApdu transmit(const CommandApdu& command) const;

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -55,16 +55,12 @@ public:
         }
     }
 
+    PCSC_CPP_DISABLE_COPY_MOVE(Context);
+
     SCARDCONTEXT handle() const { return contextHandle; }
 
 private:
     SCARDCONTEXT contextHandle = 0;
-
-    // The rule of five (C++ Core guidelines C.21).
-    Context(const Context&) = delete;
-    Context& operator=(const Context&) = delete;
-    Context(Context&&) = delete;
-    Context& operator=(Context&&) = delete;
 };
 
 } // namespace pcsc_cpp

--- a/src/SmartCard.cpp
+++ b/src/SmartCard.cpp
@@ -111,11 +111,7 @@ public:
         }
     }
 
-    // The rule of five (C++ Core guidelines C.21).
-    CardImpl(const CardImpl& other) = delete;
-    CardImpl(CardImpl&& other) noexcept = delete;
-    CardImpl& operator=(const CardImpl& other) = delete;
-    CardImpl& operator=(CardImpl&& other) noexcept = delete;
+    PCSC_CPP_DISABLE_COPY_MOVE(CardImpl);
 
     bool readerHasPinPad() const
     {


### PR DESCRIPTION
WE2-748